### PR TITLE
Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
 env:
   SOLUTION_NAME: BlorgFS.sln
   ChocolateyUseWindowsCompression: 'true'


### PR DESCRIPTION
Potential fix for [https://github.com/Chuccle/BlorgFS/security/code-scanning/3](https://github.com/Chuccle/BlorgFS/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimum permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `packages: read` for interacting with NuGet packages.
- `actions: read` for using GitHub Actions.

The `permissions` block should be added at the root level of the workflow to apply to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
