### PR TITLE
Probe of user mode supplied buffer was set to QueryDirectory length. …

### DIFF
--- a/Read.c
+++ b/Read.c
@@ -156,7 +156,7 @@ NTSTATUS BlorgVolumeRead(PIRP Irp, PIO_STACK_LOCATION IrpSp)
         {
             if (!Irp->MdlAddress && UserMode == Irp->RequestorMode)
             {
-                ProbeForRead(Irp->UserBuffer, IrpSp->Parameters.QueryDirectory.Length, sizeof(UCHAR));
+                ProbeForRead(Irp->UserBuffer, IrpSp->Parameters.Read.Length, sizeof(UCHAR));
             }
             
             RtlCopyMemory(systemBuffer, fileBuffer.BodyBuffer, realLength);


### PR DESCRIPTION
…Likely 0! Would have been a useless probe or at worst caused random oob SEH raises.